### PR TITLE
Switch from deprecated arma::is_finite to std::isfinite

### DIFF
--- a/src/rcpp_get_wecoma.cpp
+++ b/src/rcpp_get_wecoma.cpp
@@ -52,7 +52,7 @@ NumericMatrix rcpp_get_wecoma_internal(const IntegerMatrix& x,
                 continue;
             unsigned focal_class = class_index.at(focal_x);
             double focal_w = w[col * nrows + row];
-            if (na_action != "keep" && !arma::is_finite(focal_w)){
+            if (na_action != "keep" && !std::isfinite(focal_w)){
                 if (na_action == "replace"){
                     focal_w = 0.0;
                 } else if (na_action == "omit"){
@@ -72,7 +72,7 @@ NumericMatrix rcpp_get_wecoma_internal(const IntegerMatrix& x,
                     unsigned neig_class = class_index.at(neig_x);
                     double neig_w = w[neig_col * nrows + neig_row];
 
-                    if (na_action != "keep" && !arma::is_finite(neig_w)){
+                    if (na_action != "keep" && !std::isfinite(neig_w)){
                         if (na_action == "replace"){
                             neig_w = 0.0;
                         } else if (na_action == "omit"){


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just two statements. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.